### PR TITLE
Add hasOriginalMetadataSource property

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -422,3 +422,8 @@
   rdfs:comment "The relationship between an entity description and a reference" ;
   rdfs:domain :EntityDescription ;
   rdfs:range :Reference .
+
+:hasOriginalMetadataSource a rdf:Property ;
+  rdfs:comment "The source from which metadata was extracted" ;
+  rdfs:domain :EntityDescription ;
+  rdfs:range xsd:anyURI .


### PR DESCRIPTION
Added hasOriginalMetadataSource, the intention of this property is that it contains the source URI of the data which was used to populate the model. If we retrieve e.g. data from Crossref, we persist the URI we dereferenced to get the data using this property. The intention is to denote a source from which we extracted some data. Semantically, there is no overlap between this and owl:sameAs as we are specifically talking about different things (the resource as published in NVA and the resource as published elsewhere). If we had added this property to, e.g. Reference, I might have considered this to be owl:sameAs, or subclass thereof.