### PR TITLE
Add property for corresponding author

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -452,3 +452,8 @@
   rdfs:comment "The source from which metadata was extracted" ;
   rdfs:domain :EntityDescription ;
   rdfs:range xsd:anyURI .
+
+:isCorrespondingAuthor a rdf:Property ;
+  rdfs:comment "An indication that the author is a corresponding author for a publication" ;
+  rdfs:domain :Contributor ;
+  rdfs:domain xsd:boolean .

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -456,4 +456,4 @@
 :isCorrespondingAuthor a rdf:Property ;
   rdfs:comment "An indication that the author is a corresponding author for a publication" ;
   rdfs:domain :Contributor ;
-  rdfs:domain xsd:boolean .
+  rdfs:range xsd:boolean .


### PR DESCRIPTION
Added a single property that has domain :Contributor and range xsd:boolean to allow setting that a user is a corresponding author for a publication.