### PR TITLE
Np 696 add contributor email

### DIFF
--- a/ontology.ttl
+++ b/ontology.ttl
@@ -452,3 +452,8 @@
   rdfs:comment "The source from which metadata was extracted" ;
   rdfs:domain :EntityDescription ;
   rdfs:range xsd:anyURI .
+
+:isCorrespondingAuthor a rdf:Property ;
+  rdfs:comment "An indication that the author is a corresponding author for a publication" ;
+  rdfs:domain :Contributor ;
+  rdfs:domain xsd:boolean .

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -457,3 +457,8 @@
   rdfs:comment "An indication that the author is a corresponding author for a publication" ;
   rdfs:domain :Contributor ;
   rdfs:range xsd:boolean .
+
+:hasEmail a rdf:Property ;
+  rdfs:comment "The email of a contributor" ;
+  rdfs:domain :Contributor ;
+  rdfs:range xsd:string .

--- a/ontology.ttl
+++ b/ontology.ttl
@@ -456,4 +456,4 @@
 :isCorrespondingAuthor a rdf:Property ;
   rdfs:comment "An indication that the author is a corresponding author for a publication" ;
   rdfs:domain :Contributor ;
-  rdfs:domain xsd:boolean .
+  rdfs:range xsd:boolean .


### PR DESCRIPTION
The PR builds on NP-695-add-contributor-corresponding-author and should be merged into that.

We add:

- property hasEmail, with domain :Contributor and range xsd:string